### PR TITLE
feat (fonts): Force https for typography fonts

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -12,7 +12,7 @@
   <!--[if (gte IE 9) | (IEMobile)]><!-->
     <link href="/css/mqs.css" rel="stylesheet">
   <!--<![endif]-->
-  <link rel="stylesheet" type="text/css" href="//cloud.typography.com/655912/688224/css/fonts.css">
+  <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/655912/688224/css/fonts.css">
   <!--[if lt IE 9]>
     <script src="dist/html5shiv.js"></script>
   <![endif]-->


### PR DESCRIPTION
When we switched to https, this font was being loaded with http still.
This moves it to https in all cases.