### PR TITLE
feat: enable SSL

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "express": "^4.13.3",
+    "express-enforces-ssl": "^1.1.0",
     "grunt-contrib-compass": "^1.0.4",
     "grunt-contrib-connect": "^0.8.0",
     "grunt-contrib-copy": "^0.6.0",

--- a/server.js
+++ b/server.js
@@ -1,9 +1,15 @@
 var express = require('express');
+var enforceSSL = require('express-enforces-ssl');
 var app = express();
 
 app.set('port', (process.env.PORT || 5000));
 
 app.use(express.static('dist', { extensions: ['html'] }));
+
+if (process.env.ENFORCE_SSL) {
+  app.enable('trust proxy');
+  app.use(enforceSSL());
+}
 
 var server = app.listen(app.get('port'), () => {
   var host = server.address().address;


### PR DESCRIPTION
This prepares the site for enabling SSL via the `express-enforces-ssl` module.
It adds the module as a dependency, and it writes JS to check for the existence of an `ENFORCE_SSL` environment variable. When the variable is found, it will force the app to use SSL.