### PR TITLE
fix: move express.static after enforcing SSL

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,12 +4,12 @@ var app = express();
 
 app.set('port', (process.env.PORT || 5000));
 
-app.use(express.static('dist', { extensions: ['html'] }));
-
 if (process.env.ENFORCE_SSL) {
   app.enable('trust proxy');
   app.use(enforceSSL());
 }
+
+app.use(express.static('dist', { extensions: ['html'] }));
 
 var server = app.listen(app.get('port'), () => {
   var host = server.address().address;


### PR DESCRIPTION
This moves the express.static line after enforcing SSL.

To QA:

1. Run `npm start`
2. Go to http://localhost:5000
3. Check that you are redirected to https://localhost:5000