### PR TITLE
fix to be dev instead of fed

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -959,10 +959,10 @@ window.grunticon=function(e){if(e&&3===e.length){var t=window,n=!(!t.document.cr
       </div>
     </div>
     <section class="learn">
-      <section class="learn--fed">
-        <h2 class="learn--header">Frontend Designer</h1>
-        <p class="info-secondary learn--text">Level up your design skills by learning to create smart web design concepts and craft the code to build&nbsp;them.</p>
-        <a href="apply-fed.html" class="button">Learn More</a>
+      <section class="learn--dev">
+        <h2 class="learn--header">Full-Stack Developer</h1>
+        <p class="info-secondary learn--text">Take a dive into the world of clean, responsive, full-stack development as you learn what it takes to build a better web.</p>
+        <a href="apply-dev.html" class="button">Learn More</a>
       </section>
     </section>
   <footer>


### PR DESCRIPTION
I accidentally had it be the fed apprenticeship before the footer instead of keeping the dev one there. This fixes that mistake.