### PR TITLE
chore: update quick start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@ Sparkbox's new apprentice page developed by the current apprentices.
 
 ### Quick Start
 
+#### Important Notes
+- You may need to downgrade node to version 10x in order to install grunt without any issues. [Use nvm for this](https://github.com/nvm-sh/nvm).
+- If you are using an ARM based macbook (M1), you will need to run these commands in [rosetta mode](https://osxdaily.com/2020/11/18/how-run-homebrew-x86-terminal-apple-silicon-mac/).
+
 1. `npm install -g grunt-cli` to install the Grunt CLI
 2. `npm install grunt --save-dev` to install Grunt in the scope of this project
 3. `npm install`
-4. `bundle install`
-5. `grunt`
+4. `grunt`


### PR DESCRIPTION
- Add note to downgrade node to version 10x to install grunct successfully
- Add note to run quick start commands in rosetta mode if you are using an M1 macbook
- Remove `bundle install` since there are no ruby files in the project