### PR TITLE
chore: update begin application link

### DIFF
--- a/pages/apply-dev.html
+++ b/pages/apply-dev.html
@@ -34,7 +34,7 @@
   <section class="info">
     <h3 class="info-header">Applications</h3>
     <p class="info-secondary">If you feel like you&rsquo;d be a great fit for our remote full-stack apprenticeship, we encourage you to apply.</p>
-    <a href="https://apply.workable.com/sparkbox/j/D1E1D8E630/" target="_blank" class="button">Begin Application</a>
+    <a href="https://apply.workable.com/sparkbox/" target="_blank" class="button">Begin Application</a>
   </section>
   <footer>
     <div>


### PR DESCRIPTION
Jody wanted the "begin application" button on [this page](https://apprentices.seesparkbox.com/apply-dev.html) to direct to the[ Sparkbox job listing page](https://apply.workable.com/sparkbox/).

Link to message: https://sparkbox.slack.com/archives/C024R7ND6/p1625691240414000